### PR TITLE
Right-align dates when article title wraps

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -311,6 +311,7 @@ article section > p:first-of-type {
   color: rgb(var(--tree-ink-rgb) / var(--alpha-muted));
   font-size: var(--font-size-cite);
   white-space: nowrap;
+  margin-left: auto;
 }
 
 .recipes ol {


### PR DESCRIPTION
## Problem
On mobile, a long writing title ("2016 After Election Thanksgiving") forces its date onto a second flex row, where `justify-content: space-between` left-aligns the lone item — breaking the right-aligned date column on the Writings index.

## Fix
One line: give `.writing-date` `margin-left: auto`. On a shared row the auto margin absorbs the same free space `space-between` did (no visual change); on a wrapped row it pushes the date flush right.

## Verification
- 375px viewport: "Nov 2016" still wraps below the long title but is now right-aligned, matching the other rows
- Desktop: all rows identical to before

Fixes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)